### PR TITLE
fix typographic nits

### DIFF
--- a/MeetInfomaniak/Resources/de.lproj/Localizable.strings
+++ b/MeetInfomaniak/Resources/de.lproj/Localizable.strings
@@ -14,5 +14,5 @@
 "mandatoryField" = "Pflichtfeld";
 "mandatoryUserName" = "Pseudonym obligatorisch";
 "startButton" = "Dem Meeting beitreten";
-"titleCreate" = "Wie lautet Ihr Name ?";
-"titleJoin" = "Welchem Meeting möchten Sie beitreten ?";
+"titleCreate" = "Wie lautet Ihr Name?";
+"titleJoin" = "Welchem Meeting möchten Sie beitreten?";


### PR DESCRIPTION
Il n’y a pas d'espace devant `?` en allemand.